### PR TITLE
Add cross-platform display adjuster skeleton

### DIFF
--- a/src/main/java/test/five/App.java
+++ b/src/main/java/test/five/App.java
@@ -1,13 +1,34 @@
 package test.five;
 
+import test.five.display.AndroidTvDisplayAdjuster;
+import test.five.display.DisplayAdjuster;
+import test.five.display.WindowsDisplayAdjuster;
+
 /**
- * Hello world!
- *
+ * Entry point for the prototype application.
+ * It selects a DisplayAdjuster implementation based on the
+ * current operating system and applies sample settings.
  */
-public class App 
-{
-    public static void main( String[] args )
-    {
-        System.out.println( "Hello World!" );
+public class App {
+    public static void main(String[] args) {
+        DisplayAdjuster adjuster;
+        String os = System.getProperty("os.name", "").toLowerCase();
+        if (os.contains("win")) {
+            adjuster = new WindowsDisplayAdjuster();
+        } else {
+            adjuster = new AndroidTvDisplayAdjuster();
+        }
+
+        // Apply sample settings
+        adjuster.setBrightness(0.5);
+        adjuster.setColorTemperature(5000);
+
+        System.out.println("Brightness: " + adjuster.getBrightness());
+        System.out.println("Color Temperature: " + adjuster.getColorTemperature());
+
+        // Reset to safe defaults and display them
+        adjuster.resetToDefaults();
+        System.out.println("Reset Brightness: " + adjuster.getBrightness());
+        System.out.println("Reset Color Temperature: " + adjuster.getColorTemperature());
     }
 }

--- a/src/main/java/test/five/display/AndroidTvDisplayAdjuster.java
+++ b/src/main/java/test/five/display/AndroidTvDisplayAdjuster.java
@@ -1,0 +1,45 @@
+package test.five.display;
+
+/**
+ * Android TV implementation of the DisplayAdjuster interface.
+ * Like the Windows implementation, this is currently a stub
+ * that records values rather than interfacing with Android APIs.
+ */
+public class AndroidTvDisplayAdjuster implements DisplayAdjuster {
+    private double brightness = MAX_BRIGHTNESS;
+    private int colorTemperature = 6500;
+
+    @Override
+    public void setBrightness(double level) {
+        if (level < MIN_BRIGHTNESS || level > MAX_BRIGHTNESS) {
+            throw new IllegalArgumentException(
+                    "Brightness must be between " + MIN_BRIGHTNESS + " and " + MAX_BRIGHTNESS);
+        }
+        this.brightness = level;
+    }
+
+    @Override
+    public double getBrightness() {
+        return brightness;
+    }
+
+    @Override
+    public void setColorTemperature(int temperature) {
+        if (temperature < MIN_COLOR_TEMPERATURE || temperature > MAX_COLOR_TEMPERATURE) {
+            throw new IllegalArgumentException(
+                    "Temperature must be between " + MIN_COLOR_TEMPERATURE + " and " + MAX_COLOR_TEMPERATURE);
+        }
+        this.colorTemperature = temperature;
+    }
+
+    @Override
+    public int getColorTemperature() {
+        return colorTemperature;
+    }
+
+    @Override
+    public void resetToDefaults() {
+        brightness = DEFAULT_BRIGHTNESS;
+        colorTemperature = DEFAULT_COLOR_TEMPERATURE;
+    }
+}

--- a/src/main/java/test/five/display/DisplayAdjuster.java
+++ b/src/main/java/test/five/display/DisplayAdjuster.java
@@ -1,0 +1,59 @@
+package test.five.display;
+
+/**
+ * Cross-platform interface for adjusting display parameters.
+ * Implementations should handle platform specific APIs for
+ * brightness and color temperature adjustments.
+ */
+public interface DisplayAdjuster {
+    /** Minimum allowed brightness level. */
+    double MIN_BRIGHTNESS = 0.0;
+    /** Maximum allowed brightness level. */
+    double MAX_BRIGHTNESS = 1.0;
+    /** Default brightness level used by {@link #resetToDefaults()}. */
+    double DEFAULT_BRIGHTNESS = MAX_BRIGHTNESS;
+    /** Minimum allowed color temperature in Kelvin. */
+    int MIN_COLOR_TEMPERATURE = 1_000;
+    /** Maximum allowed color temperature in Kelvin. */
+    int MAX_COLOR_TEMPERATURE = 10_000;
+    /** Default color temperature in Kelvin used by {@link #resetToDefaults()}. */
+    int DEFAULT_COLOR_TEMPERATURE = 6_500;
+
+    /**
+     * Set the display brightness level.
+     *
+     * @param level brightness value from {@link #MIN_BRIGHTNESS} to
+     *              {@link #MAX_BRIGHTNESS}
+     * @throws IllegalArgumentException if the level is outside the allowed range
+     */
+    void setBrightness(double level);
+
+    /**
+     * Get the current brightness level.
+     *
+     * @return brightness value from 0.0 to 1.0
+     */
+    double getBrightness();
+
+    /**
+     * Set the color temperature.
+     *
+     * @param temperature Kelvin value for color temperature in the range
+     *                    {@link #MIN_COLOR_TEMPERATURE} –
+     *                    {@link #MAX_COLOR_TEMPERATURE}
+     * @throws IllegalArgumentException if the temperature is outside the allowed range
+     */
+    void setColorTemperature(int temperature);
+
+    /**
+     * Get the current color temperature.
+     *
+     * @return Kelvin value representing the color temperature
+     */
+    int getColorTemperature();
+
+    /**
+     * Reset both brightness and color temperature to safe defaults.
+     */
+    void resetToDefaults();
+}

--- a/src/main/java/test/five/display/WindowsDisplayAdjuster.java
+++ b/src/main/java/test/five/display/WindowsDisplayAdjuster.java
@@ -1,0 +1,46 @@
+package test.five.display;
+
+/**
+ * Windows implementation of the DisplayAdjuster interface.
+ * This class currently contains stubbed behavior and does not
+ * interact with native Windows APIs. It records the values that
+ * would be applied to the system.
+ */
+public class WindowsDisplayAdjuster implements DisplayAdjuster {
+    private double brightness = MAX_BRIGHTNESS;
+    private int colorTemperature = 6500; // neutral white
+
+    @Override
+    public void setBrightness(double level) {
+        if (level < MIN_BRIGHTNESS || level > MAX_BRIGHTNESS) {
+            throw new IllegalArgumentException(
+                    "Brightness must be between " + MIN_BRIGHTNESS + " and " + MAX_BRIGHTNESS);
+        }
+        this.brightness = level;
+    }
+
+    @Override
+    public double getBrightness() {
+        return brightness;
+    }
+
+    @Override
+    public void setColorTemperature(int temperature) {
+        if (temperature < MIN_COLOR_TEMPERATURE || temperature > MAX_COLOR_TEMPERATURE) {
+            throw new IllegalArgumentException(
+                    "Temperature must be between " + MIN_COLOR_TEMPERATURE + " and " + MAX_COLOR_TEMPERATURE);
+        }
+        this.colorTemperature = temperature;
+    }
+
+    @Override
+    public int getColorTemperature() {
+        return colorTemperature;
+    }
+
+    @Override
+    public void resetToDefaults() {
+        brightness = DEFAULT_BRIGHTNESS;
+        colorTemperature = DEFAULT_COLOR_TEMPERATURE;
+    }
+}

--- a/src/test/java/test/five/display/DisplayAdjusterTest.java
+++ b/src/test/java/test/five/display/DisplayAdjusterTest.java
@@ -1,0 +1,66 @@
+package test.five.display;
+
+import junit.framework.TestCase;
+
+/**
+ * Unit tests for DisplayAdjuster implementations.
+ */
+public class DisplayAdjusterTest extends TestCase {
+
+    public void testWindowsAdjusterStoresValues() {
+        WindowsDisplayAdjuster adjuster = new WindowsDisplayAdjuster();
+        adjuster.setBrightness(0.3);
+        adjuster.setColorTemperature(4000);
+        assertEquals(0.3, adjuster.getBrightness(), 0.0001);
+        assertEquals(4000, adjuster.getColorTemperature());
+    }
+
+    public void testAndroidAdjusterStoresValues() {
+        AndroidTvDisplayAdjuster adjuster = new AndroidTvDisplayAdjuster();
+        adjuster.setBrightness(0.7);
+        adjuster.setColorTemperature(5500);
+        assertEquals(0.7, adjuster.getBrightness(), 0.0001);
+        assertEquals(5500, adjuster.getColorTemperature());
+    }
+
+    public void testBrightnessOutOfRangeThrows() {
+        DisplayAdjuster adjuster = new WindowsDisplayAdjuster();
+        try {
+            adjuster.setBrightness(-0.1);
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+        try {
+            adjuster.setBrightness(1.1);
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+    }
+
+    public void testColorTemperatureOutOfRangeThrows() {
+        DisplayAdjuster adjuster = new AndroidTvDisplayAdjuster();
+        try {
+            adjuster.setColorTemperature(DisplayAdjuster.MIN_COLOR_TEMPERATURE - 1);
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+        try {
+            adjuster.setColorTemperature(DisplayAdjuster.MAX_COLOR_TEMPERATURE + 1);
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+    }
+
+    public void testResetToDefaults() {
+        DisplayAdjuster adjuster = new WindowsDisplayAdjuster();
+        adjuster.setBrightness(0.2);
+        adjuster.setColorTemperature(3000);
+        adjuster.resetToDefaults();
+        assertEquals(DisplayAdjuster.DEFAULT_BRIGHTNESS, adjuster.getBrightness(), 0.0001);
+        assertEquals(DisplayAdjuster.DEFAULT_COLOR_TEMPERATURE, adjuster.getColorTemperature());
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `DisplayAdjuster` interface with brightness and color temperature controls
- add Windows and Android TV stub implementations and integrate them into `App`
- create initial unit tests for the display adjusters
- enforce shared brightness and color-temperature ranges and test invalid inputs
- add default settings with a `resetToDefaults` feature and test coverage

## Testing
- `mvn -q -Djava.net.preferIPv4Stack=true test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved – Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689107ecefa88332a46550ddaddede3f