### PR TITLE
Delegate Windows display adjustments to native library

### DIFF
--- a/src/main/java/test/five/display/WindowsDisplayLibrary.java
+++ b/src/main/java/test/five/display/WindowsDisplayLibrary.java
@@ -1,0 +1,33 @@
+package test.five.display;
+
+/**
+ * Abstraction over native Windows display APIs such as Windows.Graphics.Display
+ * or DirectX. Implementations are expected to bridge to the real operating
+ * system and may throw {@link UnsupportedOperationException} when the hardware
+ * does not support a given operation.
+ */
+public interface WindowsDisplayLibrary {
+    /**
+     * @return current display brightness in the range 0.0 – 1.0
+     * @throws UnsupportedOperationException if the hardware does not expose brightness controls
+     */
+    double getBrightness();
+
+    /**
+     * @param level brightness value in the range 0.0 – 1.0
+     * @throws UnsupportedOperationException if the hardware does not support setting brightness
+     */
+    void setBrightness(double level);
+
+    /**
+     * @return current color temperature in Kelvin
+     * @throws UnsupportedOperationException if the hardware does not expose color temperature controls
+     */
+    int getColorTemperature();
+
+    /**
+     * @param temperature color temperature in Kelvin
+     * @throws UnsupportedOperationException if the hardware does not support setting color temperature
+     */
+    void setColorTemperature(int temperature);
+}

--- a/src/main/java/test/five/display/WindowsDisplayLibraryImpl.java
+++ b/src/main/java/test/five/display/WindowsDisplayLibraryImpl.java
@@ -1,0 +1,29 @@
+package test.five.display;
+
+/**
+ * Default implementation of {@link WindowsDisplayLibrary} that would invoke
+ * Windows native APIs. The actual native calls are not provided in this
+ * environment; instead the methods throw {@link UnsupportedOperationException}
+ * indicating that the functionality is unavailable.
+ */
+public class WindowsDisplayLibraryImpl implements WindowsDisplayLibrary {
+    @Override
+    public double getBrightness() {
+        throw new UnsupportedOperationException("Native brightness retrieval not implemented");
+    }
+
+    @Override
+    public void setBrightness(double level) {
+        throw new UnsupportedOperationException("Native brightness adjustment not implemented");
+    }
+
+    @Override
+    public int getColorTemperature() {
+        throw new UnsupportedOperationException("Native color temperature retrieval not implemented");
+    }
+
+    @Override
+    public void setColorTemperature(int temperature) {
+        throw new UnsupportedOperationException("Native color temperature adjustment not implemented");
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce `WindowsDisplayLibrary` abstraction and default implementation
- Rework `WindowsDisplayAdjuster` to delegate to native library and surface unsupported hardware
- Expand display adjuster tests with mocked native library and unsupported hardware scenarios

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689123cde2a08332a526723bab49d8ce