### PR TITLE
Add Android display controls and permission tests

### DIFF
--- a/src/main/java/android/content/ContentResolver.java
+++ b/src/main/java/android/content/ContentResolver.java
@@ -1,0 +1,10 @@
+package android.content;
+
+/**
+ * Minimal stub of Android's ContentResolver.
+ * This does not provide any actual functionality
+ * but allows the code to compile in a standard JVM.
+ */
+public class ContentResolver {
+}
+

--- a/src/main/java/android/content/Context.java
+++ b/src/main/java/android/content/Context.java
@@ -1,0 +1,13 @@
+package android.content;
+
+/**
+ * Minimal stub of Android's Context.
+ */
+public class Context {
+    private final ContentResolver resolver = new ContentResolver();
+
+    public ContentResolver getContentResolver() {
+        return resolver;
+    }
+}
+

--- a/src/main/java/android/provider/Settings.java
+++ b/src/main/java/android/provider/Settings.java
@@ -1,0 +1,65 @@
+package android.provider;
+
+import android.content.ContentResolver;
+import test.five.display.DisplayAdjuster;
+
+/**
+ * Minimal stub of Android's Settings provider. This class stores
+ * brightness and color temperature values in static fields and
+ * simulates permission checks and API failures for testing.
+ */
+public class Settings {
+    public static class System {
+        private static double brightness = DisplayAdjuster.DEFAULT_BRIGHTNESS;
+        private static int colorTemperature = DisplayAdjuster.DEFAULT_COLOR_TEMPERATURE;
+        private static boolean hasWritePermission = true;
+        private static boolean simulateError = false;
+
+        /** Set whether write operations should fail with SecurityException. */
+        public static void setHasWritePermission(boolean has) {
+            hasWritePermission = has;
+        }
+
+        /** Set whether any operation should fail with RuntimeException. */
+        public static void setSimulateError(boolean error) {
+            simulateError = error;
+        }
+
+        public static double getBrightness(ContentResolver resolver) {
+            if (simulateError) {
+                throw new RuntimeException("Failed to read brightness");
+            }
+            return brightness;
+        }
+
+        public static boolean putBrightness(ContentResolver resolver, double value) {
+            if (simulateError) {
+                throw new RuntimeException("Failed to write brightness");
+            }
+            if (!hasWritePermission) {
+                throw new SecurityException("WRITE_SETTINGS permission required");
+            }
+            brightness = value;
+            return true;
+        }
+
+        public static int getColorTemperature(ContentResolver resolver) {
+            if (simulateError) {
+                throw new RuntimeException("Failed to read color temperature");
+            }
+            return colorTemperature;
+        }
+
+        public static boolean putColorTemperature(ContentResolver resolver, int value) {
+            if (simulateError) {
+                throw new RuntimeException("Failed to write color temperature");
+            }
+            if (!hasWritePermission) {
+                throw new SecurityException("WRITE_SETTINGS permission required");
+            }
+            colorTemperature = value;
+            return true;
+        }
+    }
+}
+

--- a/src/main/java/test/five/display/AndroidTvDisplayAdjuster.java
+++ b/src/main/java/test/five/display/AndroidTvDisplayAdjuster.java
@@ -1,13 +1,30 @@
 package test.five.display;
 
+import android.content.Context;
+import android.content.ContentResolver;
+import android.provider.Settings;
+
 /**
  * Android TV implementation of the DisplayAdjuster interface.
- * Like the Windows implementation, this is currently a stub
- * that records values rather than interfacing with Android APIs.
+ * This version interacts with a stub of Android's Settings provider
+ * and supports starting a foreground service for continuous control.
  */
 public class AndroidTvDisplayAdjuster implements DisplayAdjuster {
-    private double brightness = MAX_BRIGHTNESS;
-    private int colorTemperature = 6500;
+    private final ContentResolver resolver;
+
+    /**
+     * Create an adjuster using a new stub Context instance.
+     */
+    public AndroidTvDisplayAdjuster() {
+        this(new Context());
+    }
+
+    /**
+     * Create an adjuster using the provided context.
+     */
+    public AndroidTvDisplayAdjuster(Context context) {
+        this.resolver = context.getContentResolver();
+    }
 
     @Override
     public void setBrightness(double level) {
@@ -15,12 +32,12 @@ public class AndroidTvDisplayAdjuster implements DisplayAdjuster {
             throw new IllegalArgumentException(
                     "Brightness must be between " + MIN_BRIGHTNESS + " and " + MAX_BRIGHTNESS);
         }
-        this.brightness = level;
+        Settings.System.putBrightness(resolver, level);
     }
 
     @Override
     public double getBrightness() {
-        return brightness;
+        return Settings.System.getBrightness(resolver);
     }
 
     @Override
@@ -29,17 +46,25 @@ public class AndroidTvDisplayAdjuster implements DisplayAdjuster {
             throw new IllegalArgumentException(
                     "Temperature must be between " + MIN_COLOR_TEMPERATURE + " and " + MAX_COLOR_TEMPERATURE);
         }
-        this.colorTemperature = temperature;
+        Settings.System.putColorTemperature(resolver, temperature);
     }
 
     @Override
     public int getColorTemperature() {
-        return colorTemperature;
+        return Settings.System.getColorTemperature(resolver);
+    }
+
+    /**
+     * Start a foreground service to maintain continuous display control.
+     */
+    public ForegroundDisplayService startContinuousControl() {
+        return ForegroundDisplayService.start(this);
     }
 
     @Override
     public void resetToDefaults() {
-        brightness = DEFAULT_BRIGHTNESS;
-        colorTemperature = DEFAULT_COLOR_TEMPERATURE;
+        setBrightness(DEFAULT_BRIGHTNESS);
+        setColorTemperature(DEFAULT_COLOR_TEMPERATURE);
     }
 }
+

--- a/src/main/java/test/five/display/ForegroundDisplayService.java
+++ b/src/main/java/test/five/display/ForegroundDisplayService.java
@@ -1,0 +1,39 @@
+package test.five.display;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Simplified foreground service stub to illustrate continuous control.
+ * In a real Android environment this would extend Service and run in the
+ * foreground. Here it merely tracks whether it has been started.
+ */
+public class ForegroundDisplayService implements Runnable {
+    private static final AtomicBoolean RUNNING = new AtomicBoolean(false);
+    private final AndroidTvDisplayAdjuster adjuster;
+
+    private ForegroundDisplayService(AndroidTvDisplayAdjuster adjuster) {
+        this.adjuster = adjuster;
+    }
+
+    /** Start the service. */
+    public static ForegroundDisplayService start(AndroidTvDisplayAdjuster adjuster) {
+        RUNNING.set(true);
+        return new ForegroundDisplayService(adjuster);
+    }
+
+    /** Stop the service. */
+    public void stop() {
+        RUNNING.set(false);
+    }
+
+    /** Whether the service is currently running. */
+    public static boolean isRunning() {
+        return RUNNING.get();
+    }
+
+    @Override
+    public void run() {
+        // No continuous loop required for the stub implementation.
+    }
+}
+

--- a/src/test/java/test/five/display/DisplayAdjusterTest.java
+++ b/src/test/java/test/five/display/DisplayAdjusterTest.java
@@ -15,12 +15,18 @@ public class DisplayAdjusterTest extends TestCase {
         assertEquals(4000, adjuster.getColorTemperature());
     }
 
-    public void testAndroidAdjusterStoresValues() {
+    public void testAndroidAdjusterQueriesActualValues() {
         AndroidTvDisplayAdjuster adjuster = new AndroidTvDisplayAdjuster();
         adjuster.setBrightness(0.7);
         adjuster.setColorTemperature(5500);
         assertEquals(0.7, adjuster.getBrightness(), 0.0001);
         assertEquals(5500, adjuster.getColorTemperature());
+
+        // Change values directly through Settings and ensure getters read them.
+        android.provider.Settings.System.putBrightness(new android.content.Context().getContentResolver(), 0.4);
+        android.provider.Settings.System.putColorTemperature(new android.content.Context().getContentResolver(), 4500);
+        assertEquals(0.4, adjuster.getBrightness(), 0.0001);
+        assertEquals(4500, adjuster.getColorTemperature());
     }
 
     public void testBrightnessOutOfRangeThrows() {
@@ -63,4 +69,31 @@ public class DisplayAdjusterTest extends TestCase {
         assertEquals(DisplayAdjuster.DEFAULT_BRIGHTNESS, adjuster.getBrightness(), 0.0001);
         assertEquals(DisplayAdjuster.DEFAULT_COLOR_TEMPERATURE, adjuster.getColorTemperature());
     }
+
+    public void testAndroidAdjusterPermissionFailure() {
+        AndroidTvDisplayAdjuster adjuster = new AndroidTvDisplayAdjuster();
+        android.provider.Settings.System.setHasWritePermission(false);
+        try {
+            adjuster.setBrightness(0.5);
+            fail("Expected SecurityException");
+        } catch (SecurityException expected) {
+            // expected
+        } finally {
+            android.provider.Settings.System.setHasWritePermission(true);
+        }
+    }
+
+    public void testAndroidAdjusterApiError() {
+        AndroidTvDisplayAdjuster adjuster = new AndroidTvDisplayAdjuster();
+        android.provider.Settings.System.setSimulateError(true);
+        try {
+            adjuster.getBrightness();
+            fail("Expected RuntimeException");
+        } catch (RuntimeException expected) {
+            // expected
+        } finally {
+            android.provider.Settings.System.setSimulateError(false);
+        }
+    }
 }
+


### PR DESCRIPTION
## Summary
- Implement Android TV display adjuster using stubbed Settings API to read/write brightness and color temperature
- Add foreground service stub for continuous display control
- Expand tests to cover permission denials and simulated API errors

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689123cf5cf883328c8459aeb60e5ecd