### PR TITLE
Add profile manager with scheduling

### DIFF
--- a/src/main/java/test/five/profile/Profile.java
+++ b/src/main/java/test/five/profile/Profile.java
@@ -1,0 +1,29 @@
+package test.five.profile;
+
+/**
+ * Represents a saved user profile containing brightness and
+ * color temperature settings.
+ */
+public class Profile {
+    private final String user;
+    private final double brightness;
+    private final int colorTemperature;
+
+    public Profile(String user, double brightness, int colorTemperature) {
+        this.user = user;
+        this.brightness = brightness;
+        this.colorTemperature = colorTemperature;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public double getBrightness() {
+        return brightness;
+    }
+
+    public int getColorTemperature() {
+        return colorTemperature;
+    }
+}

--- a/src/main/java/test/five/profile/ProfileManager.java
+++ b/src/main/java/test/five/profile/ProfileManager.java
@@ -1,0 +1,138 @@
+package test.five.profile;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import test.five.display.DisplayAdjuster;
+
+/**
+ * Manages user profiles and their associated schedules. Profiles are persisted
+ * to disk as a small JSON document and loaded at construction time.
+ */
+public class ProfileManager {
+    private final Map<String, Profile> profiles = new HashMap<>();
+    private final List<ProfileSchedule> schedules = new ArrayList<>();
+    private final Path storagePath;
+
+    public ProfileManager(Path storagePath) {
+        this.storagePath = storagePath;
+        load();
+    }
+
+    /**
+     * Add or replace a profile for a user. The profile is immediately persisted
+     * to disk.
+     */
+    public void addProfile(Profile profile) {
+        profiles.put(profile.getUser(), profile);
+        save();
+    }
+
+    /** Retrieve a profile for a given user. */
+    public Profile getProfile(String user) {
+        return profiles.get(user);
+    }
+
+    /**
+     * Schedule a user's profile for a time-of-day range and optional activity.
+     * The schedule information is persisted to disk.
+     */
+    public void scheduleProfile(String user, LocalTime start, LocalTime end, String activity) {
+        schedules.add(new ProfileSchedule(user, start, end, activity));
+        save();
+    }
+
+    /**
+     * Apply the scheduled profile for the given time and activity using the provided adjuster.
+     * If no schedule matches, nothing is applied.
+     */
+    public void applyScheduledProfile(LocalTime time, String activity, DisplayAdjuster adjuster) {
+        for (ProfileSchedule schedule : schedules) {
+            if (schedule.matches(time, activity)) {
+                Profile profile = profiles.get(schedule.getUser());
+                if (profile != null) {
+                    adjuster.setBrightness(profile.getBrightness());
+                    adjuster.setColorTemperature(profile.getColorTemperature());
+                }
+                return;
+            }
+        }
+    }
+
+    /** Persist profiles and schedules to disk as JSON. */
+    private void save() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\"profiles\":[");
+        boolean first = true;
+        for (Profile profile : profiles.values()) {
+            if (!first) sb.append(',');
+            sb.append("{\"user\":\"").append(profile.getUser()).append("\",")
+              .append("\"brightness\":").append(profile.getBrightness()).append(',')
+              .append("\"colorTemperature\":").append(profile.getColorTemperature()).append('}');
+            first = false;
+        }
+        sb.append("],\"schedules\":[");
+        first = true;
+        for (ProfileSchedule schedule : schedules) {
+            if (!first) sb.append(',');
+            sb.append("{\"user\":\"").append(schedule.getUser()).append("\",")
+              .append("\"start\":\"").append(schedule.getStart()).append("\",")
+              .append("\"end\":\"").append(schedule.getEnd()).append("\",")
+              .append("\"activity\":");
+            if (schedule.getActivity() == null) {
+                sb.append("null");
+            } else {
+                sb.append('\"').append(schedule.getActivity()).append('\"');
+            }
+            sb.append('}');
+            first = false;
+        }
+        sb.append("]}");
+        try {
+            Files.write(storagePath, sb.toString().getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            // Swallowing exception for simplicity in this stub implementation
+        }
+    }
+
+    /** Load profiles and schedules from disk if the storage file exists. */
+    private void load() {
+        profiles.clear();
+        schedules.clear();
+        if (!Files.exists(storagePath)) {
+            return;
+        }
+        try {
+            String content = new String(Files.readAllBytes(storagePath), StandardCharsets.UTF_8);
+            Pattern profilePattern = Pattern.compile("\\{\\\"user\\\":\\\"(.*?)\\\",\\\"brightness\\\":(.*?),\\\"colorTemperature\\\":(.*?)\\}");
+            Matcher pm = profilePattern.matcher(content);
+            while (pm.find()) {
+                String user = pm.group(1);
+                double brightness = Double.parseDouble(pm.group(2));
+                int color = Integer.parseInt(pm.group(3));
+                profiles.put(user, new Profile(user, brightness, color));
+            }
+            Pattern schedulePattern = Pattern.compile("\\{\\\"user\\\":\\\"(.*?)\\\",\\\"start\\\":\\\"(.*?)\\\",\\\"end\\\":\\\"(.*?)\\\",\\\"activity\\\":(null|\\\"(.*?)\\\")\\}");
+            Matcher sm = schedulePattern.matcher(content);
+            while (sm.find()) {
+                String user = sm.group(1);
+                LocalTime start = LocalTime.parse(sm.group(2));
+                LocalTime end = LocalTime.parse(sm.group(3));
+                String rawActivity = sm.group(4);
+                String activity = "null".equals(rawActivity) ? null : sm.group(5);
+                schedules.add(new ProfileSchedule(user, start, end, activity));
+            }
+        } catch (IOException e) {
+            // ignore errors in this simple implementation
+        }
+    }
+}

--- a/src/main/java/test/five/profile/ProfileSchedule.java
+++ b/src/main/java/test/five/profile/ProfileSchedule.java
@@ -1,0 +1,49 @@
+package test.five.profile;
+
+import java.time.LocalTime;
+
+/**
+ * Associates a user profile with a time-of-day range and an optional activity name.
+ */
+public class ProfileSchedule {
+    private final String user;
+    private final LocalTime start;
+    private final LocalTime end;
+    private final String activity; // may be null for any activity
+
+    public ProfileSchedule(String user, LocalTime start, LocalTime end, String activity) {
+        this.user = user;
+        this.start = start;
+        this.end = end;
+        this.activity = activity;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public LocalTime getStart() {
+        return start;
+    }
+
+    public LocalTime getEnd() {
+        return end;
+    }
+
+    public String getActivity() {
+        return activity;
+    }
+
+    /**
+     * Determine whether this schedule is active for the provided time and activity.
+     *
+     * @param time current time
+     * @param currentActivity current activity name, may be null
+     * @return true if the schedule should apply
+     */
+    public boolean matches(LocalTime time, String currentActivity) {
+        boolean withinTime = (time.equals(start) || time.isAfter(start)) && time.isBefore(end);
+        boolean activityMatch = activity == null || activity.equals(currentActivity);
+        return withinTime && activityMatch;
+    }
+}

--- a/src/test/java/test/five/profile/ProfileManagerTest.java
+++ b/src/test/java/test/five/profile/ProfileManagerTest.java
@@ -1,0 +1,48 @@
+package test.five.profile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalTime;
+
+import junit.framework.TestCase;
+import test.five.display.WindowsDisplayAdjuster;
+
+/**
+ * Tests for the ProfileManager and scheduling logic.
+ */
+public class ProfileManagerTest extends TestCase {
+
+    public void testProfileCreationAndRetrieval() throws IOException {
+        Path temp = Files.createTempFile("profiles", ".json");
+        ProfileManager manager = new ProfileManager(temp);
+        manager.addProfile(new Profile("alice", 0.5, 5000));
+        Profile retrieved = manager.getProfile("alice");
+        assertNotNull(retrieved);
+        assertEquals(0.5, retrieved.getBrightness(), 0.0001);
+        assertEquals(5000, retrieved.getColorTemperature());
+    }
+
+    public void testProfilesPersistedToDisk() throws IOException {
+        Path temp = Files.createTempFile("profiles", ".json");
+        ProfileManager manager = new ProfileManager(temp);
+        manager.addProfile(new Profile("bob", 0.7, 4000));
+        // New manager should load existing profile
+        ProfileManager reloaded = new ProfileManager(temp);
+        Profile retrieved = reloaded.getProfile("bob");
+        assertNotNull(retrieved);
+        assertEquals(0.7, retrieved.getBrightness(), 0.0001);
+        assertEquals(4000, retrieved.getColorTemperature());
+    }
+
+    public void testScheduledApplication() throws IOException {
+        Path temp = Files.createTempFile("profiles", ".json");
+        ProfileManager manager = new ProfileManager(temp);
+        manager.addProfile(new Profile("carol", 0.3, 6000));
+        manager.scheduleProfile("carol", LocalTime.of(6, 0), LocalTime.of(18, 0), "work");
+        WindowsDisplayAdjuster adjuster = new WindowsDisplayAdjuster();
+        manager.applyScheduledProfile(LocalTime.of(7, 0), "work", adjuster);
+        assertEquals(0.3, adjuster.getBrightness(), 0.0001);
+        assertEquals(6000, adjuster.getColorTemperature());
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `Profile`, `ProfileManager`, and `ProfileSchedule` to store brightness and color settings per user
- persist profiles and schedules to JSON and reload at startup
- support applying profiles based on time-of-day and optional activity
- add unit tests verifying persistence and scheduled application

## Testing
- `mvn -q test` *(fails: Network is unreachable for org.apache.maven.plugins:maven-resources-plugin:3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_689123d341808332a5f2298852195f42