### PR TITLE
Add Windows installer build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,14 @@ This project uses a mirrored Maven repository to avoid outages at the default Ma
    ```
 
 These steps ensure repeatable builds without requiring external network access after the initial dependency download.
+
+## Windows installer
+
+On a Windows host with JDK 17 or newer, an MSI installer can be generated
+using the bundled PowerShell script:
+
+```powershell
+./scripts/buildWindowsInstaller.ps1
+```
+
+The resulting installer will be created in the `target` directory.

--- a/pom.xml
+++ b/pom.xml
@@ -36,4 +36,30 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>windows-installer</id>
+      <activation>
+        <os>
+          <family>windows</family>
+        </os>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.panteleyev</groupId>
+            <artifactId>jpackage-maven-plugin</artifactId>
+            <version>1.9.1</version>
+            <configuration>
+              <mainClass>test.five.App</mainClass>
+              <input>${project.build.directory}</input>
+              <mainJar>${project.build.finalName}.jar</mainJar>
+              <name>testFive</name>
+              <type>msi</type>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/scripts/buildWindowsInstaller.ps1
+++ b/scripts/buildWindowsInstaller.ps1
@@ -1,0 +1,5 @@
+# Builds a Windows installer using the jpackage Maven plugin.
+# Requires JDK 17 or later on a Windows host.
+
+mvn -q clean package -Pwindows-installer
+


### PR DESCRIPTION
## Summary
- Configure Maven to build a Windows MSI installer via a jpackage-based profile
- Add PowerShell script for generating the installer
- Document Windows installer generation in README

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_689252b9ecf08332a38078345e731ed8